### PR TITLE
Updates as part of writing guides

### DIFF
--- a/api-example/src/main/java/se/curity/examples/spark/SparkServerExample.java
+++ b/api-example/src/main/java/se/curity/examples/spark/SparkServerExample.java
@@ -33,13 +33,9 @@ import static spark.Spark.port;
 
 public class SparkServerExample implements SparkApplication
 {
-
-    private static final Logger _logger = LoggerFactory.getLogger(SparkServerExample.class);
-
     @Override
     public void init()
     {
-        _logger.debug("Initializing OAuth protected API");
         get("/hello_world", (req, res) ->{
             AuthenticatedUser user = (AuthenticatedUser)req.attribute(OAuthFilter.PRINCIPAL);
             return "Hello "+ user.getSubject() + " from an OAuth protected world!";
@@ -49,7 +45,7 @@ public class SparkServerExample implements SparkApplication
     private void initStandalone() throws ServletException
     {
         init();
-        OAuthFilter filter = getOpaqueFilter();
+        OAuthFilter filter = getJwtFilter();
         before(((request, response) -> {
             filter.doFilter(request.raw(), response.raw(), null);
             if(response.raw().isCommitted())
@@ -69,7 +65,7 @@ public class SparkServerExample implements SparkApplication
     {
         EmbeddedSparkJwtFilterConfig filterParams = new EmbeddedSparkJwtFilterConfig("localhost",
                 "8443",
-                "/oauth/v2/metadata/jwks",
+                "/oauth/v2/oauth-anonymous/jwks",
                 "read",
                 "3600");
         OAuthFilter filter = new OAuthJwtFilter();

--- a/api-example/src/main/java/se/curity/examples/spark/SparkServerExample.java
+++ b/api-example/src/main/java/se/curity/examples/spark/SparkServerExample.java
@@ -33,9 +33,12 @@ import static spark.Spark.port;
 
 public class SparkServerExample implements SparkApplication
 {
+    private static final Logger _logger = LoggerFactory.getLogger(SparkServerExample.class);
+
     @Override
     public void init()
     {
+        _logger.debug("Initializing OAuth protected API");
         get("/hello_world", (req, res) ->{
             AuthenticatedUser user = (AuthenticatedUser)req.attribute(OAuthFilter.PRINCIPAL);
             return "Hello "+ user.getSubject() + " from an OAuth protected world!";

--- a/api-example/src/main/webapp/WEB-INF/web.xml
+++ b/api-example/src/main/webapp/WEB-INF/web.xml
@@ -43,7 +43,7 @@
         </init-param>
         <init-param>
             <param-name>jsonWebKeysPath</param-name>
-            <param-value>/oauth/v2/metadata/jwks</param-value>
+            <param-value>/oauth/v2/oauth-anonymous/jwks</param-value>
         </init-param>
         <init-param>
             <param-name>scope</param-name>


### PR DESCRIPTION
- Use the standard path to the JWKS endpoint
- Use the JWT filter by default since JWTs in APIs are our standard recommendation